### PR TITLE
Serialized Beat Object

### DIFF
--- a/beatmachine/__main__.py
+++ b/beatmachine/__main__.py
@@ -8,10 +8,10 @@ import beatmachine as bm
 def main():
     parser = argparse.ArgumentParser(prog="beatmachine")
     parser.add_argument("--version", "-v", action="version", version=bm.__version__)
-    parser.add_argument("--input", "-i", help="Input MP3 file", required=True)
+    parser.add_argument("--input", "-i", help="Input MP3 or Beat file", required=True)
     parser.add_argument("--effects", "-e", help="JSON effects to apply", required=True)
     parser.add_argument("--output", "-o", help="Output MP3 file", required=True)
-    parser.add_argument("--serialize", "-s", help="Output serialized beats file (can be used in place of MP3)", required=False, action='store_true')
+    parser.add_argument("--serialize", "-s", help="Output serialized beat file (can be used in place of MP3)", required=False, action='store_true')
     parser.add_argument("--bpm", "-b", type=int, help="BPM estimate")
     parser.add_argument(
         "--tolerance",

--- a/beatmachine/__main__.py
+++ b/beatmachine/__main__.py
@@ -1,15 +1,16 @@
 import json
 import os
-
+import sys
+import pickle
 import beatmachine as bm
 import argparse
 
-
 def main():
     parser = argparse.ArgumentParser(prog="beatmachine")
-    parser.add_argument("--input", "-i", help="Input MP3 file", required=True)
+    parser.add_argument("--input", "-i", help="Input MP3 or beats file", required=True)
     parser.add_argument("--effects", "-e", help="JSON effects to apply", required=True)
     parser.add_argument("--output", "-o", help="Output MP3 file", required=True)
+    parser.add_argument("--beat", "-b", help="Output beats file (can be used in place of the MP3)", required=False, action='store_true')
     args = parser.parse_args()
 
     if os.path.isfile(args.effects):
@@ -19,10 +20,32 @@ def main():
         effects_json = json.loads(args.effects)
 
     effects = [bm.effects.load_from_dict(e) for e in effects_json]
-
-    print("Locating beats (this may take a while)")
-    beats = bm.Beats.from_song(args.input)
     effect_count = len(effects)
+    filename = os.path.splitext(args.input)
+    if os.path.isfile(args.input):
+        if filename[1]=='.mp3':
+            print("Locating beats (this may take a while)")
+            beats = bm.Beats.from_song(args.input)
+            if args.beat is True:
+                with open(filename[0]+".beat", "wb") as fp:
+                    fp.write(pickle.dumps(beats))
+                    fp.close()
+                    print("Wrote beats out to "+filename[0]+".beat. Use this instead of the MP3 to speed up processing.")
+        elif filename[1]=='.beat':
+            with open(args.input, "rb") as fp:
+                try:
+                    beats = pickle.load(fp)
+                    fp.close()
+                except Exception:
+                    print("Something is wrong with your previously generated beats file. Please try rebuilding it from the MP3.")
+                    fp.close()
+                    sys.exit()
+        else:
+            print("Please specify either an MP3 or a previously generated beats file.")
+            sys.exit()
+    else:
+        print("Please specify either an MP3 or a previously generated beats file.")
+        sys.exit()
 
     for i, effect in enumerate(effects):
         print(f"Applying effect {i + 1}/{effect_count} ({effect.__effect_name__})")
@@ -31,7 +54,6 @@ def main():
     print("Rendering song")
     beats.consolidate().export(args.output)
     print("Wrote output to", args.output)
-
 
 if __name__ == "__main__":
     main()

--- a/beatmachine/__main__.py
+++ b/beatmachine/__main__.py
@@ -21,7 +21,7 @@ def main():
 
     effects = [bm.effects.load_from_dict(e) for e in effects_json]
     effect_count = len(effects)
-    filename = os.path.splitext(args.input)
+    filename = os.path.splitext(args.input.lower())
     if os.path.isfile(args.input):
         if filename[1]=='.mp3':
             print("Locating beats (this may take a while)")

--- a/beatmachine/beats.py
+++ b/beatmachine/beats.py
@@ -3,7 +3,6 @@ from functools import reduce
 from typing import List, BinaryIO, Union
 
 import numpy as np
-import soundfile
 
 from . import loader, effects
 
@@ -72,15 +71,7 @@ class Beats:
             ],
             stdin=subprocess.PIPE,
         )
-
-        soundfile.write(
-            p.stdin,
-            self.to_ndarray(),
-            samplerate=self._sr,
-            format="RAW",
-            subtype="PCM_16",
-        )
-
+        p.communicate(input=self.to_ndarray().tobytes())
         p.stdin.close()
         p.wait()
 


### PR DESCRIPTION
Wanted to speed up the ability to play around with files without waiting the whole processing time each run. If you specify the -b argument it'll write out a .beat file serialized with Pickle so that that computation doesn't need to be re-run.